### PR TITLE
doc: Fix the wrong link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Alpine Linux](https://www.alpinelinux.org/) is a lightweight distribution that uses `BusyBox` and `musl` as the base system. As such, the base Alpine Docker image is very small, roughly 5.6MB, and only contains the bare minimum to get up and running.
 
-This image is based on the base [Alpine dockr image](https://hub.docker.com/r/library/alpine) plus [`tini`]([https://github.com/Yelp/dumb-init](https://github.com/krallin/tini)) for better signal handling.
+This image is based on the base [Alpine dockr image](https://hub.docker.com/r/library/alpine) plus [`tini`](https://github.com/krallin/tini) for better signal handling.
 
 
 ## Usage


### PR DESCRIPTION
The link was corrupted with wrong code.